### PR TITLE
Add limit order deployment testing

### DIFF
--- a/tests/base-sepolia-limit-fork/conftest.py
+++ b/tests/base-sepolia-limit-fork/conftest.py
@@ -1,0 +1,294 @@
+import os
+from functools import wraps
+import pytest
+from synthetix import Synthetix
+from synthetix.utils import ether_to_wei, format_wei, format_ether
+from ape import networks, chain
+
+
+# find an address with a lot of usdc
+SNX_DEPLOYER = "0x48914229deDd5A9922f44441ffCCfC2Cb7856Ee9"
+KWENTA_REFERRER = "0x3bD64247d879AF879e6f6e62F81430186391Bdb8"
+
+
+def chain_fork(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with networks.parse_network_choice("base:sepolia-fork:foundry"):
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+# fixtures
+@chain_fork
+@pytest.fixture(scope="package")
+def snx():
+    # set up the snx instance
+    snx = Synthetix(
+        provider_rpc=chain.provider.uri,
+        network_id=84532,
+        referrer=KWENTA_REFERRER,
+        is_fork=True,
+        request_kwargs={"timeout": 120},
+        cannon_config={
+            "package": "synthetix-omnibus",
+            "version": "45",
+            "preset": "limit",
+        },
+    )
+    update_prices(snx)
+    mint_usdc(snx)
+    return snx
+
+
+@chain_fork
+def update_prices(snx):
+    pyth_contract = snx.contracts["Pyth"]["contract"]
+
+    # get feed ids
+    feed_ids = list(snx.pyth.price_feed_ids.values())
+
+    pyth_response = snx.pyth.get_price_from_ids(feed_ids)
+    price_update_data = pyth_response["price_update_data"]
+
+    # create the tx
+    tx_params = snx._get_tx_params(value=len(feed_ids))
+    tx_params = pyth_contract.functions.updatePriceFeeds(
+        price_update_data
+    ).build_transaction(tx_params)
+
+    # submit the tx
+    tx_hash = snx.execute_transaction(tx_params)
+    tx_receipt = snx.wait(tx_hash)
+    if tx_receipt["status"] != 1:
+        raise Exception("Price feed update failed")
+    else:
+        snx.logger.info("Price feeds updated")
+
+
+@chain_fork
+def mint_usdc(snx):
+    """The instance can mint USDC tokens"""
+    # check usdc balance
+    usdc_package = snx.contracts["usdc_mock_collateral"]["MintableToken"]
+    usdc_contract = snx.web3.eth.contract(
+        address=usdc_package["address"], abi=usdc_package["abi"]
+    )
+
+    usdc_balance = usdc_contract.functions.balanceOf(snx.address).call()
+    usdc_balance = format_wei(usdc_balance)
+
+    # get some usdc
+    mint_amount = max(100000 - usdc_balance, 0)
+    if mint_amount > 0:
+        snx.web3.provider.make_request("anvil_impersonateAccount", [SNX_DEPLOYER])
+
+        mint_amount = format_ether(mint_amount, 6)
+        tx_params = usdc_contract.functions.mint(
+            mint_amount, snx.address
+        ).build_transaction(
+            {
+                "from": SNX_DEPLOYER,
+                "nonce": snx.web3.eth.get_transaction_count(SNX_DEPLOYER),
+            }
+        )
+
+        # Send the transaction directly without signing
+        tx_hash = snx.web3.eth.send_transaction(tx_params)
+        receipt = snx.wait(tx_hash)
+        if receipt["status"] != 1:
+            raise Exception("USDC Mint failed")
+        else:
+            snx.logger.info(f"USDC minted")
+
+        # wrap some USDC
+        approve_tx_1 = snx.approve(
+            usdc_contract.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx_1)
+
+        wrap_tx = snx.spot.wrap(75000, market_name="sUSDC", submit=True)
+        snx.wait(wrap_tx)
+        snx.logger.info(f"sUSDC wrapped")
+
+        # sell some for sUSD
+        approve_tx_2 = snx.spot.approve(
+            snx.spot.market_proxy.address, market_name="sUSDC", submit=True
+        )
+        snx.wait(approve_tx_2)
+
+        susd_tx = snx.spot.atomic_order("sell", 50000, market_name="sUSDC", submit=True)
+        snx.wait(susd_tx)
+        snx.logger.info(f"sUSDC sold for sUSD")
+
+
+@chain_fork
+def mint_ausdc(snx):
+    """The instance can mint aUSDC tokens and vault tokens"""
+    # check ausdc balance
+    # aUSDC token
+    ausdc_package = snx.contracts["erc_4626_to_assets_ratio_oracle"][
+        "ausdc_token_mock"
+    ]["MintableToken"]
+    ausdc = snx.web3.eth.contract(
+        address=ausdc_package["address"], abi=ausdc_package["abi"]
+    )
+
+    # stataUSDC oracle
+    statausdc_oracle_package = snx.contracts["erc_4626_to_assets_ratio_oracle"][
+        "ERC4626ToAssetsRatioOracle"
+    ]
+    statausdc_oracle = snx.web3.eth.contract(
+        address=statausdc_oracle_package["address"],
+        abi=statausdc_oracle_package["abi"],
+    )
+
+    # stataUSDC vault
+    vault_address = statausdc_oracle.functions.VAULT_ADDRESS().call()
+    vault = snx.web3.eth.contract(
+        address=vault_address,
+        abi=snx.contracts["common"]["ERC4626"]["abi"],
+    )
+
+    ausdc_balance = ausdc.functions.balanceOf(snx.address).call()
+    ausdc_balance = format_wei(ausdc_balance, 6)
+
+    deposit_amount = 100000
+    mint_amount = max(deposit_amount - ausdc_balance, 0)
+    if mint_amount > 0:
+        mint_amount = format_ether(mint_amount, 6)
+        tx_params = ausdc.functions.mint(mint_amount, snx.address).build_transaction(
+            {
+                "from": snx.address,
+                "nonce": snx.web3.eth.get_transaction_count(snx.address),
+            }
+        )
+
+        # Send the transaction directly without signing
+        tx_hash = snx.web3.eth.send_transaction(tx_params)
+        receipt = snx.wait(tx_hash)
+        if receipt["status"] != 1:
+            raise Exception("aUSDC Mint failed")
+        else:
+            snx.logger.info(f"aUSDC minted")
+
+        # deposit to the vault
+        snx.nonce = snx.web3.eth.get_transaction_count(snx.address)
+        approve_tx = snx.approve(ausdc.address, vault.address, submit=True)
+        snx.wait(approve_tx)
+
+    deposit_tx_params = vault.functions.mint(
+        format_ether(deposit_amount, 6), snx.address
+    ).build_transaction(
+        {
+            "from": snx.address,
+            "nonce": snx.web3.eth.get_transaction_count(snx.address),
+        }
+    )
+    deposit_tx = snx.web3.eth.send_transaction(deposit_tx_params)
+    deposit_receipt = snx.wait(deposit_tx)
+    snx.logger.info(f"aUSDC deposited")
+
+
+@pytest.fixture(scope="module")
+def contracts(snx):
+    # create some needed contracts
+    weth = snx.contracts["WETH"]["contract"]
+
+    # USDC token
+    usdc_package = snx.contracts["usdc_mock_collateral"]["MintableToken"]
+    usdc = snx.web3.eth.contract(
+        address=usdc_package["address"], abi=usdc_package["abi"]
+    )
+
+    # aUSDC token
+    ausdc_package = snx.contracts["erc_4626_to_assets_ratio_oracle"][
+        "ausdc_token_mock"
+    ]["MintableToken"]
+    ausdc = snx.web3.eth.contract(
+        address=ausdc_package["address"], abi=ausdc_package["abi"]
+    )
+
+    # stataUSDC oracle
+    statausdc_oracle_package = snx.contracts["erc_4626_to_assets_ratio_oracle"][
+        "ERC4626ToAssetsRatioOracle"
+    ]
+    statausdc_oracle = snx.web3.eth.contract(
+        address=statausdc_oracle_package["address"],
+        abi=statausdc_oracle_package["abi"],
+    )
+
+    # stataUSDC vault
+    vault_address = statausdc_oracle.functions.VAULT_ADDRESS().call()
+    vault = snx.web3.eth.contract(
+        address=vault_address,
+        abi=snx.contracts["common"]["ERC4626"]["abi"],
+    )
+
+    return {
+        "WETH": weth,
+        "USDC": usdc,
+        "aUSDC": ausdc,
+        "stataUSDCOracle": statausdc_oracle,
+        "StataUSDC": vault,
+    }
+
+
+@chain_fork
+@pytest.fixture(scope="module")
+def account_id(snx):
+    # check if an account exists
+    account_ids = snx.perps.get_account_ids()
+
+    final_account_id = None
+    for account_id in account_ids:
+        margin_info = snx.perps.get_margin_info(account_id)
+        positions = snx.perps.get_open_positions(account_id=account_id)
+
+        if margin_info["total_collateral_value"] == 0 and len(positions) == 0:
+            snx.logger.info(f"Account {account_id} is empty")
+            final_account_id = account_id
+            break
+        else:
+            snx.logger.info(f"Account {account_id} has margin")
+
+    if final_account_id is None:
+        snx.logger.info("Creating a new perps account")
+
+        create_tx = snx.perps.create_account(submit=True)
+        snx.wait(create_tx)
+
+        account_ids = snx.perps.get_account_ids()
+        final_account_id = account_ids[-1]
+
+    yield final_account_id
+
+
+@chain_fork
+@pytest.fixture(scope="function")
+def new_account_id(snx):
+    snx.logger.info("Creating a new perps account")
+    create_tx = snx.perps.create_account(submit=True)
+    snx.wait(create_tx)
+
+    account_ids = snx.perps.get_account_ids()
+    new_account_id = account_ids[-1]
+
+    yield new_account_id
+
+
+@chain_fork
+@pytest.fixture(scope="function")
+def core_account_id(snx):
+    # create a core account
+    tx_hash = snx.core.create_account(submit=True)
+    tx_receipt = snx.wait(tx_hash)
+
+    assert tx_hash is not None
+    assert tx_receipt is not None
+    assert tx_receipt.status == 1
+
+    account_id = snx.core.account_ids[-1]
+    snx.logger.info(f"Created core account: {account_id}")
+    return account_id

--- a/tests/base-sepolia-limit-fork/test_base_sepolia_limit_fork_core.py
+++ b/tests/base-sepolia-limit-fork/test_base_sepolia_limit_fork_core.py
@@ -1,0 +1,151 @@
+import pytest
+from conftest import chain_fork
+
+# constants
+USD_TEST_AMOUNT = 1000
+
+# tests
+@chain_fork
+def test_core_module(snx):
+    """The instance has a core module"""
+    assert snx.core is not None
+    assert snx.core.core_proxy is not None
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", USD_TEST_AMOUNT, 6),
+    ],
+)
+def test_wrap_deposit_flow(
+    snx,
+    contracts,
+    core_account_id,
+    token_name,
+    test_amount,
+    decimals,
+):
+    """The instance can deposit token"""
+    token = contracts[token_name]
+    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
+
+    ## wrap
+    # check the allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+
+    if allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(test_amount, market_id=market_id, submit=True)
+    snx.wait(wrap_tx)
+
+    # approve collateral
+    allowance = snx.allowance(wrapped_token.address, snx.core.core_proxy.address)
+    if allowance < test_amount:
+        approve_core_tx = snx.approve(
+            wrapped_token.address, snx.core.core_proxy.address, submit=True
+        )
+        snx.wait(approve_core_tx)
+
+    # deposit the token
+    deposit_tx_hash = snx.core.deposit(
+        wrapped_token.address,
+        test_amount,
+        account_id=core_account_id,
+        submit=True,
+    )
+    deposit_tx_receipt = snx.wait(deposit_tx_hash)
+
+    assert deposit_tx_hash is not None
+    assert deposit_tx_receipt is not None
+    assert deposit_tx_receipt.status == 1
+
+    # withdraw the token
+    withdraw_tx_hash = snx.core.withdraw(
+        test_amount,
+        token_address=wrapped_token.address,
+        account_id=core_account_id,
+        submit=True,
+    )
+    withdraw_tx_receipt = snx.wait(withdraw_tx_hash)
+
+    assert withdraw_tx_hash is not None
+    assert withdraw_tx_receipt is not None
+    assert withdraw_tx_receipt.status == 1
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", USD_TEST_AMOUNT, 6),
+    ],
+)
+def test_wrap_delegate_flow(
+    snx,
+    contracts,
+    core_account_id,
+    token_name,
+    test_amount,
+    decimals,
+):
+    """The instance can delegate token"""
+    token = contracts[token_name]
+    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
+
+    ## wrap
+    # check the allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+
+    if allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(test_amount, market_id=market_id, submit=True)
+    snx.wait(wrap_tx)
+
+    # approve collateral
+    allowance = snx.allowance(wrapped_token.address, snx.core.core_proxy.address)
+    if allowance < test_amount:
+        approve_core_tx = snx.approve(
+            wrapped_token.address, snx.core.core_proxy.address, submit=True
+        )
+        snx.wait(approve_core_tx)
+
+    # deposit the token
+    deposit_tx_hash = snx.core.deposit(
+        wrapped_token.address,
+        test_amount,
+        account_id=core_account_id,
+        submit=True,
+    )
+    deposit_tx_receipt = snx.wait(deposit_tx_hash)
+
+    assert deposit_tx_hash is not None
+    assert deposit_tx_receipt is not None
+    assert deposit_tx_receipt.status == 1
+
+    # delegate the collateral
+    delegate_tx_hash = snx.core.delegate_collateral(
+        wrapped_token.address,
+        test_amount,
+        1,
+        account_id=core_account_id,
+        submit=True,
+    )
+    delegate_tx_receipt = snx.wait(delegate_tx_hash)
+
+    assert delegate_tx_hash is not None
+    assert delegate_tx_receipt is not None
+    assert delegate_tx_receipt.status == 1

--- a/tests/base-sepolia-limit-fork/test_base_sepolia_limit_fork_perps.py
+++ b/tests/base-sepolia-limit-fork/test_base_sepolia_limit_fork_perps.py
@@ -1,0 +1,201 @@
+import pytest
+import time
+import math
+from conftest import chain_fork
+from ape import chain
+
+# tests
+MARKET_NAMES = [
+    "ETH",
+]
+TEST_COLLATERAL_AMOUNT = 1000
+TEST_POSITION_SIZE_USD = 500
+
+
+def mine_block(snx, chain, seconds=3):
+    time.sleep(seconds)
+    timestamp = int(time.time())
+
+    chain.mine(1, timestamp=timestamp)
+    snx.logger.info(f"Block mined at timestamp {timestamp}")
+
+
+def test_perps_module(snx):
+    """The instance has a perps module"""
+    assert snx.perps is not None
+    assert snx.perps.market_proxy is not None
+    assert snx.perps.account_proxy is not None
+    assert snx.perps.account_ids is not None
+    assert snx.perps.markets_by_id is not None
+    assert snx.perps.markets_by_name is not None
+
+
+@chain_fork
+def test_perps_markets(snx):
+    markets_by_id, markets_by_name = snx.perps.get_markets()
+
+    snx.logger.info(f"Markets by id: {markets_by_id}")
+    snx.logger.info(f"Markets by name: {markets_by_name}")
+
+    assert markets_by_id is not None
+    assert markets_by_name is not None
+
+    for market in MARKET_NAMES:
+        assert (
+            market in markets_by_name
+        ), f"Market {market} is missing in markets_by_name"
+
+        market_summary = markets_by_name[market]
+        assert market_summary["market_name"] == market
+        assert market_summary["index_price"] > 0
+        assert market_summary["feed_id"] is not None
+
+
+@chain_fork
+def test_perps_account_fetch(snx, account_id):
+    """The instance can fetch account ids"""
+    account_ids = snx.perps.get_account_ids()
+    snx.logger.info(
+        f"Address: {snx.address} - accounts: {len(account_ids)} - account_ids: {account_ids}"
+    )
+    assert len(account_ids) > 0
+    assert account_id in account_ids
+
+
+@chain_fork
+def test_modify_collateral(snx, account_id):
+    """Test modify collateral"""
+    # get starting collateral and sUSD balance
+    margin_info_start = snx.perps.get_margin_info(account_id)
+    susd_balance_start = snx.get_susd_balance()
+
+    # check allowance
+    allowance = snx.spot.get_allowance(
+        snx.perps.market_proxy.address, market_name="sUSD"
+    )
+    if allowance < TEST_COLLATERAL_AMOUNT:
+        approve_tx = snx.spot.approve(
+            snx.perps.market_proxy.address, market_name="sUSD", submit=True
+        )
+        snx.wait(approve_tx)
+
+    # modify collateral
+    modify_tx = snx.perps.modify_collateral(
+        TEST_COLLATERAL_AMOUNT, market_name="sUSD", account_id=account_id, submit=True
+    )
+    snx.wait(modify_tx)
+
+    # check the result
+    margin_info_end = snx.perps.get_margin_info(account_id)
+    susd_balance_end = snx.get_susd_balance()
+
+    assert (
+        margin_info_end["total_collateral_value"]
+        > margin_info_start["total_collateral_value"]
+    )
+    assert susd_balance_end["balance"] < susd_balance_start["balance"]
+    assert (
+        susd_balance_end["balance"]
+        == susd_balance_start["balance"] - TEST_COLLATERAL_AMOUNT
+    )
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "market_name",
+    MARKET_NAMES,
+)
+def test_account_flow(snx, new_account_id, market_name):
+    mine_block(snx, chain, seconds=0)
+
+    # check allowance
+    allowance = snx.spot.get_allowance(
+        snx.perps.market_proxy.address, market_name="sUSD"
+    )
+    if allowance < TEST_COLLATERAL_AMOUNT:
+        approve_tx = snx.spot.approve(
+            snx.perps.market_proxy.address, market_name="sUSD", submit=True
+        )
+        snx.wait(approve_tx)
+
+    # deposit collateral
+    modify_tx = snx.perps.modify_collateral(
+        TEST_COLLATERAL_AMOUNT,
+        market_name="sUSD",
+        account_id=new_account_id,
+        submit=True,
+    )
+    modify_receipt = snx.wait(modify_tx)
+    assert modify_receipt["status"] == 1
+
+    # check the price
+    index_price = snx.perps.markets_by_name[market_name]["index_price"]
+
+    # commit order
+    position_size = TEST_POSITION_SIZE_USD / index_price
+    commit_tx = snx.perps.commit_order(
+        position_size,
+        market_name=market_name,
+        account_id=new_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt = snx.wait(commit_tx)
+    assert commit_receipt["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx = snx.perps.settle_order(
+        account_id=new_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt = snx.wait(settle_tx)
+
+    # check the result
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=new_account_id
+    )
+    assert round(position["position_size"], 12) == round(position_size, 12)
+
+    # get the position size
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=new_account_id
+    )
+    size = position["position_size"]
+
+    # commit order
+    commit_tx_2 = snx.perps.commit_order(
+        -size,
+        market_name=market_name,
+        account_id=new_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt_2 = snx.wait(commit_tx_2)
+    assert commit_receipt_2["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx_2 = snx.perps.settle_order(
+        account_id=new_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt_2 = snx.wait(settle_tx_2)
+
+    # check the result
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=new_account_id
+    )
+    assert position["position_size"] == 0
+
+    # check the margin and withdraw
+    margin_info = snx.perps.get_margin_info(new_account_id)
+    withdrawable_margin = margin_info["withdrawable_margin"]
+    withdrawable_margin = math.floor(withdrawable_margin * 1e8) / 1e8
+
+    modify_tx_2 = snx.perps.modify_collateral(
+        -withdrawable_margin,
+        market_name="sUSD",
+        account_id=new_account_id,
+        submit=True,
+    )
+    modify_receipt_2 = snx.wait(modify_tx_2)
+    assert modify_receipt_2["status"] == 1

--- a/tests/base-sepolia-limit-fork/test_base_sepolia_limit_fork_spot.py
+++ b/tests/base-sepolia-limit-fork/test_base_sepolia_limit_fork_spot.py
@@ -1,0 +1,256 @@
+import pytest
+from synthetix.utils import ether_to_wei, wei_to_ether, format_wei
+from conftest import chain_fork
+
+# constants
+TEST_AMOUNT = 100
+
+# tests
+
+
+@chain_fork
+def test_spot_module(snx):
+    """The instance has a spot module"""
+    assert snx.spot is not None
+    assert snx.spot.market_proxy is not None
+
+
+@chain_fork
+def test_spot_markets(snx):
+    """The instance has spot markets"""
+    snx.logger.info(f"Markets: {snx.spot.markets_by_name}")
+    assert snx.spot.markets_by_name is not None
+    assert len(snx.spot.markets_by_name) == len(snx.spot.markets_by_id)
+    assert "sUSD" in snx.spot.markets_by_name
+    assert "sUSDC" in snx.spot.markets_by_name
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", TEST_AMOUNT, 6),
+    ],
+)
+def test_spot_wrapper(snx, contracts, token_name, test_amount, decimals):
+    """The instance can wrap and unwrap an asset"""
+    token = contracts[token_name]
+    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
+
+    # make sure we have some USDC
+    starting_balance_wei = token.functions.balanceOf(snx.address).call()
+    starting_balance = format_wei(starting_balance_wei, decimals)
+
+    starting_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert starting_balance > test_amount
+
+    ## wrap
+    # check the allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+
+    if allowance < test_amount:
+        # reset nonce manually to avoid nonce issues
+        snx.nonce = snx.web3.eth.get_transaction_count(snx.address)
+
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(test_amount, market_id=market_id, submit=True)
+    snx.wait(wrap_tx)
+
+    # get new balances
+    wrapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    wrapped_balance = format_wei(wrapped_balance_wei, decimals)
+
+    wrapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert wrapped_balance == starting_balance - test_amount
+    assert wrapped_synth_balance == starting_synth_balance + test_amount
+
+    ## unwrap
+    # check the allowance
+    wrapped_allowance = snx.allowance(
+        wrapped_token.address, snx.spot.market_proxy.address
+    )
+
+    if wrapped_allowance < test_amount:
+        # reset nonce manually to avoid nonce issues
+        snx.nonce = snx.web3.eth.get_transaction_count(snx.address)
+
+        # approve
+        approve_tx = snx.approve(
+            wrapped_token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    unwrap_tx = snx.spot.wrap(-test_amount, market_id=market_id, submit=True)
+    snx.wait(unwrap_tx)
+
+    # get new balances
+    unwrapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    unwrapped_balance = format_wei(unwrapped_balance_wei, decimals)
+
+    unwrapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert unwrapped_balance == wrapped_balance + test_amount
+    assert unwrapped_synth_balance == wrapped_synth_balance - test_amount
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", TEST_AMOUNT, 6),
+    ],
+)
+def test_spot_atomic_order(snx, contracts, token_name, test_amount, decimals):
+    """The instance can wrap USDC for sUSDC and commit an atomic order to sell for sUSD"""
+    token = contracts[token_name]
+    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
+    susd_token = snx.spot.markets_by_id[0]["contract"]
+
+    # make sure we have some USDC
+    starting_balance_wei = token.functions.balanceOf(snx.address).call()
+    starting_balance = format_wei(starting_balance_wei, decimals)
+
+    starting_synth_balance = snx.spot.get_balance(market_id=market_id)
+    starting_susd_balance = snx.spot.get_balance(market_id=0)
+
+    assert starting_balance > test_amount
+
+    ## wrap
+    # check the allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+
+    if allowance < test_amount:
+        # reset nonce manually to avoid nonce issues
+        snx.nonce = snx.web3.eth.get_transaction_count(snx.address)
+
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(test_amount, market_id=market_id, submit=True)
+    snx.wait(wrap_tx)
+
+    # get new balances
+    wrapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    wrapped_balance = format_wei(wrapped_balance_wei, decimals)
+
+    wrapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert wrapped_balance == starting_balance - test_amount
+    assert wrapped_synth_balance == starting_synth_balance + test_amount
+
+    ## sell for sUSD
+    # check the allowance
+    wrapped_allowance = snx.allowance(
+        wrapped_token.address, snx.spot.market_proxy.address
+    )
+
+    if wrapped_allowance < test_amount:
+        # reset nonce manually to avoid nonce issues
+        snx.nonce = snx.web3.eth.get_transaction_count(snx.address)
+
+        # approve
+        approve_tx = snx.approve(
+            wrapped_token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    # atomic swap
+    swap_tx = snx.spot.atomic_order(
+        "sell", test_amount, market_id=market_id, submit=True
+    )
+    swap_receipt = snx.wait(swap_tx)
+
+    assert swap_receipt is not None
+    assert swap_receipt.status == 1
+
+    # check balances
+    swapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    swapped_balance = format_wei(swapped_balance_wei, decimals)
+
+    swapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+    swapped_susd_balance = snx.spot.get_balance(market_id=0)
+
+    assert swapped_balance == starting_balance - test_amount
+    assert swapped_synth_balance == wrapped_synth_balance - test_amount
+    assert swapped_susd_balance == starting_susd_balance + test_amount
+
+    ## buy wrapped token back
+    # check the allowance
+    susd_allowance = snx.allowance(susd_token.address, snx.spot.market_proxy.address)
+
+    if susd_allowance < test_amount:
+        # reset nonce manually to avoid nonce issues
+        snx.nonce = snx.web3.eth.get_transaction_count(snx.address)
+
+        # approve
+        approve_tx = snx.approve(
+            susd_token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    # atomic swap
+    buy_tx = snx.spot.atomic_order(
+        "buy",
+        test_amount,
+        market_id=market_id,
+        submit=True,
+    )
+    buy_receipt = snx.wait(buy_tx)
+
+    assert buy_receipt is not None
+    assert buy_receipt.status == 1
+
+    # check balances
+    bought_balance_wei = token.functions.balanceOf(snx.address).call()
+    bought_balance = format_wei(bought_balance_wei, decimals)
+
+    bought_synth_balance = snx.spot.get_balance(market_id=market_id)
+    bought_susd_balance = snx.spot.get_balance(market_id=0)
+
+    assert bought_balance == swapped_balance
+    assert bought_synth_balance == swapped_synth_balance + test_amount
+    assert bought_susd_balance == swapped_susd_balance - test_amount
+
+    ## unwrap
+    # check the allowance
+    wrapped_allowance = snx.allowance(
+        wrapped_token.address, snx.spot.market_proxy.address
+    )
+
+    if wrapped_allowance < bought_synth_balance:
+        # reset nonce manually to avoid nonce issues
+        snx.nonce = snx.web3.eth.get_transaction_count(snx.address)
+
+        # approve
+        approve_tx = snx.approve(
+            wrapped_token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    unwrap_tx = snx.spot.wrap(-test_amount, market_id=market_id, submit=True)
+    unwrap_receipt = snx.wait(unwrap_tx)
+
+    assert unwrap_tx is not None
+    assert unwrap_receipt is not None
+    assert unwrap_receipt.status == 1
+
+    # get new balances
+    unwrapped_balance_wei = token.functions.balanceOf(snx.address).call()
+    unwrapped_balance = format_wei(unwrapped_balance_wei, decimals)
+
+    unwrapped_synth_balance = snx.spot.get_balance(market_id=market_id)
+
+    assert unwrapped_balance == starting_balance
+    assert unwrapped_synth_balance == bought_synth_balance - test_amount

--- a/tests/base-sepolia-limit-fork/test_base_sepolia_limit_fork_synthetix.py
+++ b/tests/base-sepolia-limit-fork/test_base_sepolia_limit_fork_synthetix.py
@@ -1,0 +1,35 @@
+from conftest import chain_fork
+from synthetix.utils import ether_to_wei, wei_to_ether
+
+# tests
+
+
+@chain_fork
+def test_snx(snx):
+    """The instance has a Synthetix instance"""
+    assert snx is not None
+
+
+@chain_fork
+def test_contracts(contracts):
+    """The instance has necessary contracts"""
+    assert contracts["WETH"] is not None
+    assert contracts["USDC"] is not None
+
+
+@chain_fork
+def test_wrap_eth(snx):
+    """The instance can wrap ETH"""
+    tx_hash_wrap = snx.wrap_eth(0.01, submit=True)
+    tx_receipt_wrap = snx.wait(tx_hash_wrap)
+
+    assert tx_hash_wrap is not None
+    assert tx_receipt_wrap is not None
+    assert tx_receipt_wrap.status == 1
+
+    tx_hash_unwrap = snx.wrap_eth(-0.01, submit=True)
+    tx_receipt_unwrap = snx.wait(tx_hash_unwrap)
+
+    assert tx_hash_unwrap is not None
+    assert tx_receipt_unwrap is not None
+    assert tx_receipt_unwrap.status == 1

--- a/tests/base-sepolia-limit/conftest.py
+++ b/tests/base-sepolia-limit/conftest.py
@@ -1,0 +1,169 @@
+import os
+from functools import wraps
+import pytest
+from synthetix import Synthetix
+from synthetix.utils import ether_to_wei, format_wei, format_ether
+from ape import networks, chain
+
+
+# find an address with a lot of usdc
+SNX_DEPLOYER = "0x48914229deDd5A9922f44441ffCCfC2Cb7856Ee9"
+KWENTA_REFERRER = "0x3bD64247d879AF879e6f6e62F81430186391Bdb8"
+
+
+def chain_fork(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with networks.parse_network_choice("base:sepolia:alchemy"):
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+# fixtures
+@chain_fork
+@pytest.fixture(scope="package")
+def snx():
+    # set up the snx instance
+    snx = Synthetix(
+        provider_rpc=chain.provider.uri,
+        address=os.getenv("ADDRESS"),
+        private_key=os.getenv("PRIVATE_KEY"),
+        network_id=84532,
+        referrer=KWENTA_REFERRER,
+        cannon_config={
+            "package": "synthetix-omnibus",
+            "version": "45",
+            "preset": "limit",
+        },
+    )
+    # mint_usd(snx)
+    return snx
+
+
+@chain_fork
+def update_prices(snx):
+    pyth_contract = snx.contracts["Pyth"]["contract"]
+
+    # get feed ids
+    feed_ids = list(snx.pyth.price_feed_ids.values())
+
+    pyth_response = snx.pyth.get_price_from_ids(feed_ids)
+    price_update_data = pyth_response["price_update_data"]
+
+    # create the tx
+    tx_params = snx._get_tx_params(value=len(feed_ids))
+    tx_params = pyth_contract.functions.updatePriceFeeds(
+        price_update_data
+    ).build_transaction(tx_params)
+
+    # submit the tx
+    tx_hash = snx.execute_transaction(tx_params)
+    tx_receipt = snx.wait(tx_hash)
+    if tx_receipt["status"] != 1:
+        raise Exception("Price feed update failed")
+    else:
+        snx.logger.info("Price feeds updated")
+
+
+@chain_fork
+def mint_usd(snx):
+    """The instance can mint sUSD tokens from USDC"""
+    # get contracts
+    usdc = snx.contracts["usdc_mock_collateral"]["MintableToken"]['contract']
+    
+    # log USDC balance
+    usdc_balance = usdc.functions.balanceOf(snx.address).call() / 1e6
+    snx.logger.info(f"USDC balance: {usdc_balance}")
+
+    # wrap some USDC
+    approve_tx_1 = snx.approve(usdc.address, snx.spot.market_proxy.address, submit=True)
+    snx.wait(approve_tx_1)
+
+    wrap_tx = snx.spot.wrap(100000, market_name="sUSDC", submit=True)
+    snx.wait(wrap_tx)
+
+    # sell some for sUSD
+    approve_tx_2 = snx.spot.approve(
+        snx.spot.market_proxy.address, market_name="sUSDC", submit=True
+    )
+    snx.wait(approve_tx_2)
+
+    susd_tx = snx.spot.atomic_order("sell", 100000, market_name="sUSDC", submit=True)
+    snx.wait(susd_tx)
+
+
+@pytest.fixture(scope="module")
+def contracts(snx):
+    # create some needed contracts
+    weth = snx.contracts["WETH"]["contract"]
+
+    # USDC token
+    usdc_package = snx.contracts["usdc_mock_collateral"]["MintableToken"]
+    usdc = snx.web3.eth.contract(
+        address=usdc_package["address"], abi=usdc_package["abi"]
+    )
+
+    return {
+        "WETH": weth,
+        "USDC": usdc,
+    }
+
+
+@chain_fork
+@pytest.fixture(scope="module")
+def account_id(snx):
+    # check if an account exists
+    account_ids = snx.perps.get_account_ids()
+
+    final_account_id = None
+    for account_id in account_ids:
+        margin_info = snx.perps.get_margin_info(account_id)
+        positions = snx.perps.get_open_positions(account_id=account_id)
+
+        if margin_info["total_collateral_value"] == 0 and len(positions) == 0:
+            snx.logger.info(f"Account {account_id} is empty")
+            final_account_id = account_id
+            break
+        else:
+            snx.logger.info(f"Account {account_id} has margin")
+
+    if final_account_id is None:
+        snx.logger.info("Creating a new perps account")
+
+        create_tx = snx.perps.create_account(submit=True)
+        snx.wait(create_tx)
+
+        account_ids = snx.perps.get_account_ids()
+        final_account_id = account_ids[-1]
+
+    yield final_account_id
+
+
+@chain_fork
+@pytest.fixture(scope="function")
+def perps_account_id(snx):
+    snx.logger.info("Creating a new perps account")
+    create_tx = snx.perps.create_account(submit=True)
+    snx.wait(create_tx)
+
+    account_ids = snx.perps.get_account_ids()
+    new_account_id = account_ids[-1]
+
+    yield new_account_id
+
+
+@chain_fork
+@pytest.fixture(scope="function")
+def core_account_id(snx):
+    # create a core account
+    tx_hash = snx.core.create_account(submit=True)
+    tx_receipt = snx.wait(tx_hash)
+
+    assert tx_hash is not None
+    assert tx_receipt is not None
+    assert tx_receipt.status == 1
+
+    account_id = snx.core.account_ids[-1]
+    snx.logger.info(f"Created core account: {account_id}")
+    return account_id

--- a/tests/base-sepolia-limit/test_base_sepolia_limit_core.py
+++ b/tests/base-sepolia-limit/test_base_sepolia_limit_core.py
@@ -1,0 +1,82 @@
+import pytest
+from conftest import chain_fork
+
+# constants
+USD_TEST_AMOUNT = 250000
+
+# tests
+@chain_fork
+def test_core_module(snx):
+    """The instance has a core module"""
+    assert snx.core is not None
+    assert snx.core.core_proxy is not None
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "token_name, test_amount, decimals",
+    [
+        ("USDC", USD_TEST_AMOUNT, 6),
+    ],
+)
+def test_wrap_delegate_flow(
+    snx,
+    contracts,
+    core_account_id,
+    token_name,
+    test_amount,
+    decimals,
+):
+    """The instance can delegate token"""
+    token = contracts[token_name]
+    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
+
+    ## wrap
+    # check the allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+
+    if allowance < test_amount:
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(test_amount, market_id=market_id, submit=True)
+    snx.wait(wrap_tx)
+
+    # approve collateral
+    allowance = snx.allowance(wrapped_token.address, snx.core.core_proxy.address)
+    if allowance < test_amount:
+        approve_core_tx = snx.approve(
+            wrapped_token.address, snx.core.core_proxy.address, submit=True
+        )
+        snx.wait(approve_core_tx)
+
+    # deposit the token
+    deposit_tx_hash = snx.core.deposit(
+        wrapped_token.address,
+        test_amount,
+        account_id=core_account_id,
+        submit=True,
+    )
+    deposit_tx_receipt = snx.wait(deposit_tx_hash)
+
+    assert deposit_tx_hash is not None
+    assert deposit_tx_receipt is not None
+    assert deposit_tx_receipt.status == 1
+
+    # delegate the collateral
+    delegate_tx_hash = snx.core.delegate_collateral(
+        wrapped_token.address,
+        test_amount,
+        1,
+        account_id=core_account_id,
+        submit=True,
+    )
+    delegate_tx_receipt = snx.wait(delegate_tx_hash)
+
+    assert delegate_tx_hash is not None
+    assert delegate_tx_receipt is not None
+    assert delegate_tx_receipt.status == 1

--- a/tests/base-sepolia-limit/test_base_sepolia_limit_perps.py
+++ b/tests/base-sepolia-limit/test_base_sepolia_limit_perps.py
@@ -1,0 +1,145 @@
+import pytest
+import time
+import math
+from conftest import chain_fork
+from ape import chain
+
+# tests
+MARKET_NAMES = [
+    "ETH",
+]
+TEST_COLLATERAL_AMOUNT = 5000
+TEST_POSITION_SIZE_USD = 500
+
+
+def mine_block(snx, chain, seconds=3):
+    time.sleep(seconds)
+    timestamp = int(time.time())
+
+    chain.mine(1, timestamp=timestamp)
+    snx.logger.info(f"Block mined at timestamp {timestamp}")
+
+
+def test_perps_module(snx):
+    """The instance has a perps module"""
+    assert snx.perps is not None
+    assert snx.perps.market_proxy is not None
+    assert snx.perps.account_proxy is not None
+    assert snx.perps.account_ids is not None
+    assert snx.perps.markets_by_id is not None
+    assert snx.perps.markets_by_name is not None
+
+
+@chain_fork
+def test_perps_markets(snx):
+    markets_by_id, markets_by_name = snx.perps.get_markets()
+
+    snx.logger.info(f"Markets by id: {markets_by_id}")
+    snx.logger.info(f"Markets by name: {markets_by_name}")
+
+    assert markets_by_id is not None
+    assert markets_by_name is not None
+
+    for market in MARKET_NAMES:
+        assert (
+            market in markets_by_name
+        ), f"Market {market} is missing in markets_by_name"
+
+        market_summary = markets_by_name[market]
+        assert market_summary["market_name"] == market
+        assert market_summary["index_price"] > 0
+        assert market_summary["feed_id"] is not None
+
+
+@chain_fork
+def test_perps_owners(snx):
+    account = snx.contracts["perpsFactory"]["PerpsAccountProxy"]["contract"]
+
+    account_1 = 170141183460469231731687303715884105727
+    account_2 = 170141183460469231731687303715884105728
+
+    owner_1 = snx.perps.market_proxy.functions.getAccountOwner(
+        account_1
+    ).call()
+
+    owner_2 = snx.perps.market_proxy.functions.getAccountOwner(
+        account_2
+    ).call()
+
+    snx.logger.info(f"Owner 1: {owner_1} for account {account_1}")
+    snx.logger.info(f"Owner 2: {owner_2} for account {account_2}")
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "deliver_address",
+    [
+        "0xB484748E3e6406fB845dc06FED02D578533c45D7",
+        "0xCf2E738a01E1977233353795168029FD7FE7A048",
+    ],
+)
+def test_modify_collateral(snx, deliver_address, perps_account_id):
+    """Test modify collateral"""
+    # get starting collateral and sUSD balance
+    margin_info_start = snx.perps.get_margin_info(perps_account_id)
+    susd_balance_start = snx.get_susd_balance()
+    snx.logger.info(f"Starting sUSD balance: {susd_balance_start}")
+
+    # check allowance
+    allowance = snx.spot.get_allowance(
+        snx.perps.market_proxy.address, market_name="sUSD"
+    )
+    if allowance < TEST_COLLATERAL_AMOUNT:
+        approve_tx = snx.spot.approve(
+            snx.perps.market_proxy.address, market_name="sUSD", submit=True
+        )
+        snx.wait(approve_tx)
+
+    # modify collateral
+    modify_tx = snx.perps.modify_collateral(
+        TEST_COLLATERAL_AMOUNT,
+        market_name="sUSD",
+        account_id=perps_account_id,
+        submit=True,
+    )
+    snx.wait(modify_tx)
+
+    # check the result
+    margin_info_end = snx.perps.get_margin_info(perps_account_id)
+    susd_balance_end = snx.get_susd_balance()
+
+    assert (
+        margin_info_end["total_collateral_value"]
+        > margin_info_start["total_collateral_value"]
+    )
+    assert susd_balance_end["balance"] < susd_balance_start["balance"]
+    assert (
+        susd_balance_end["balance"]
+        == susd_balance_start["balance"] - TEST_COLLATERAL_AMOUNT
+    )
+
+    # # transfer the account
+    # account = snx.contracts["perpsFactory"]["PerpsAccountProxy"]["contract"]
+
+    # # approve the transfer
+    # snx.logger.info(f"{account.functions.balanceOf(snx.address).call()}")
+    # snx.logger.info(f"{account.functions.balanceOf(snx.address).call()}")
+
+    # tx_params = snx._get_tx_params()
+    # tx_params = account.functions.approve(
+    #     snx.address, perps_account_id
+    # ).build_transaction(tx_params)
+
+    # tx_hash = snx.execute_transaction(tx_params)
+    # tx_receipt = snx.wait(tx_hash)
+    # assert tx_receipt.status == 1
+
+    # # transfer the token
+    # tx_params = snx._get_tx_params()
+    # tx_params = account.functions.transferFrom(
+    #     snx.address, deliver_address, perps_account_id
+    # ).build_transaction(tx_params)
+
+    # tx_hash = snx.execute_transaction(tx_params)
+    # tx_receipt = snx.wait(tx_hash)
+    # assert tx_receipt.status == 1


### PR DESCRIPTION
Add support to test the `limit` preset deployment. Additionally, add some testnet tasks to deposit collateral to the LP and create accounts for integrators.

Changes:
- Add `base-sepolia-limit-fork` tests. These are a complete fork test suite for the limit order deployment
- Add `base-sepolia-limit` tests. These do some minimal transactions to set the deployment up for activity, by depositing LP and creating some funded accounts.