### PR TITLE
Arbitrum mainnet tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 eth-ape
 python-dotenv
 ipykernel
-synthetix==0.1.16
+synthetix==0.1.17

--- a/scripts/eth_sep_settings.py
+++ b/scripts/eth_sep_settings.py
@@ -1,0 +1,102 @@
+import click
+import re
+from functools import wraps
+from ape import accounts, networks, chain, Contract
+from synthetix import Synthetix
+
+
+# functions
+def format_key(key):
+    # Remove 'D18' suffix and capitalize 'oracle' to 'Oracle'
+    key = key.replace("D18", "").replace("oracle", "Oracle")
+
+    # Split camelCase into separate words
+    words = re.findall(r"[A-Z]?[a-z]+|[A-Z]{2,}(?=[A-Z][a-z]|\d|\W|$)|\d+", key)
+
+    # Capitalize each word and join them with spaces
+    return " ".join(word.capitalize() for word in words)
+
+
+def format_value(key, value):
+    if isinstance(value, bool):
+        return "Enabled" if value else "Disabled"
+    if "D18" in key:
+        return f"{value / 1e18:.6f}"
+    return str(value)
+
+
+def print_collateral_config(snx, collateral_config):
+    click.echo("\n--- Collateral Configuration ---")
+    token = Contract(
+        address=collateral_config.tokenAddress,
+        abi=snx.contracts["common"]["ERC20"]["abi"],
+    )
+    token_name = token.call_view_method("name")
+    click.echo(f"Token: {token_name}")
+
+    for key, value in collateral_config.items():
+        formatted_key = format_key(key)
+        formatted_value = format_value(key, value)
+        click.echo(f"{formatted_key}: {formatted_value}")
+
+
+# wrapper for chain fork
+def chain_fork(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with networks.parse_network_choice("ethereum:sepolia-fork:foundry"):
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+@chain_fork
+def main():
+    click.echo(
+        f"""
+    Fork provider started: {chain.provider.uri}
+    Network name: {chain.provider.network.name}
+    """
+    )
+
+    snx = Synthetix(
+        provider_rpc=chain.provider.uri,
+        is_fork=True,
+        request_kwargs={"timeout": 120},
+        cannon_config={
+            "package": "synthetix-omnibus",
+            "version": "latest",
+            "preset": "main",
+        },
+    )
+
+    PerpsProxy = Contract(
+        address=snx.perps.market_proxy.address,
+        abi=snx.perps.market_proxy.abi,
+    )
+
+    CoreProxy = Contract(
+        address=snx.core.core_proxy.address,
+        abi=snx.core.core_proxy.abi,
+    )
+
+    collateral_configurations = CoreProxy.call_view_method(
+        "getCollateralConfigurations", False
+    )
+    for index, collateral in enumerate(collateral_configurations, 1):
+        click.echo(f"\nCollateral #{index}")
+        print_collateral_config(snx, collateral)
+
+    click.echo(f"\nTotal Collateral Configurations: {len(collateral_configurations)}")
+    pass
+
+
+@click.command()
+def cli():
+    click.echo("Starting the script...")
+    main()
+    click.prompt(
+        "Press enter to stop",
+        default="exit",
+        show_default=False,
+    )

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,13 +29,13 @@ To run the tests, use the `ape` command from the root directory of the project. 
 
 ```bash
 # Run tests on a fork
-ape test tests/arbitrum-mainnet-fork/ --arbitrum:mainnet-fork:foundry
+ape test tests/arbitrum-mainnet-fork/ --network arbitrum:mainnet-fork:foundry
 
 # Run tests on a live network
-ape test tests/arbitrum-sepolia-octo/ --arbitrum:sepolia:alchemy
+ape test tests/arbitrum-sepolia-octo/ --network arbitrum:sepolia:alchemy
 
 # Run a specific test file
-ape test tests/arbitrum-sepolia-octo-fork/test_arbitrum_sepolia_octo_perps.py --arbitrum:sepolia-fork:foundry
+ape test tests/arbitrum-sepolia-octo-fork/test_arbitrum_sepolia_octo_perps.py --network arbitrum:sepolia-fork:foundry
 ```
 
 Tests that run on forked networks should seed an RPC signer account with the necessary tokens and balances to run the tests. When running on live networks, ensure that you're providing an address and private key in the `.env` file. Ensure that the account has the necessary tokens and balances to run the tests.

--- a/tests/arbitrum-mainnet-fork/conftest.py
+++ b/tests/arbitrum-mainnet-fork/conftest.py
@@ -52,8 +52,8 @@ def snx(pytestconfig):
     steal_tbtc(snx)
     mint_usdx_with_usdc(snx)
     wrap_eth(snx)
-    update_prices(snx)
     mine_block(snx, chain)
+    update_prices(snx)
     return snx
 
 

--- a/tests/arbitrum-mainnet-fork/conftest.py
+++ b/tests/arbitrum-mainnet-fork/conftest.py
@@ -5,12 +5,17 @@ from synthetix import Synthetix
 from synthetix.utils import ether_to_wei
 from ape import networks, chain
 from utils.arb_helpers import mock_arb_precompiles
+from utils.chain_helpers import mine_block
 
 # constants
-SNX_DEPLOYER_ADDRESS = "0x48914229deDd5A9922f44441ffCCfC2Cb7856Ee9"
+SNX_DEPLOYER = "0xD3DFa13CDc7c133b1700c243f03A8C6Df513A93b"
 USDC_WHALE = "0xB38e8c17e38363aF6EbdCb3dAE12e0243582891D"
 ARB_WHALE = "0xB38e8c17e38363aF6EbdCb3dAE12e0243582891D"
 USDE_WHALE = "0xb3C24D9dcCC2Ec5f778742389ffe448E295B84e0"
+
+USDC_MINT_AMOUNT = 1000000
+USDC_LP_AMOUNT = 500000
+USDX_MINT_AMOUNT = 100000
 
 
 def chain_fork(func):
@@ -32,18 +37,23 @@ def snx(pytestconfig):
         network_id=42161,
         is_fork=True,
         request_kwargs={"timeout": 120},
+        ipfs_gateway="http://localhost:8080/ipfs/",
         cannon_config={
-            "package": "synthetix-omnibus",
-            "version": "5",
-            "preset": "main",
+            "ipfs_hash": "QmQkuzn1c8C1EMDpepC1XX3Mszp2Xo6CqG4r8x5vjgHVa4",
+            # "package": "synthetix-omnibus",
+            # "version": "5",
+            # "preset": "main",
         },
     )
     mock_arb_precompiles(snx)
-    update_prices(snx)
+    set_timeout(snx)
     steal_arb(snx)
     steal_usdc(snx)
     steal_usde(snx)
+    mint_usdx_with_usdc(snx)
     wrap_eth(snx)
+    update_prices(snx)
+    mine_block(snx, chain)
     return snx
 
 
@@ -60,6 +70,30 @@ def contracts(snx):
         "ARB": arb,
         "USDe": usde,
     }
+
+
+@chain_fork
+def set_timeout(snx):
+    """Set the account activity timeout to zero"""
+    snx.web3.provider.make_request("anvil_impersonateAccount", [SNX_DEPLOYER])
+
+    tx_params = snx.core.core_proxy.functions.setConfig(
+        "0x6163636f756e7454696d656f7574576974686472617700000000000000000000",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    ).build_transaction(
+        {
+            "from": SNX_DEPLOYER,
+            "nonce": snx.web3.eth.get_transaction_count(SNX_DEPLOYER),
+        }
+    )
+
+    # Send the transaction directly without signing
+    tx_hash = snx.web3.eth.send_transaction(tx_params)
+    receipt = snx.wait(tx_hash)
+    if receipt["status"] != 1:
+        raise Exception(f"Set timeout failed")
+    else:
+        snx.logger.info(f"Timeout set")
 
 
 @chain_fork
@@ -130,8 +164,8 @@ def steal_usdc(snx):
     usdc_balance = usdc_balance / 10**6
 
     # get some usdc
-    if usdc_balance < 100000:
-        transfer_amount = int((100000 - usdc_balance) * 10**6)
+    if usdc_balance < USDC_MINT_AMOUNT:
+        transfer_amount = int((USDC_MINT_AMOUNT - usdc_balance) * 10**6)
         snx.web3.provider.make_request("anvil_impersonateAccount", [USDC_WHALE])
 
         tx_params = usdc_contract.functions.transfer(
@@ -199,19 +233,128 @@ def steal_usde(snx):
 
 
 @chain_fork
+def mint_usdx_with_usdc(snx):
+    """The instance can mint USDx tokens using USDC as collateral"""
+    # set up token contracts
+    token = snx.contracts["USDC"]["contract"]
+    usdc_decimals = token.functions.decimals().call()
+
+    susd = snx.contracts["system"]["USDProxy"]["contract"]
+    susd_decimals = susd.functions.decimals().call()
+
+    # get an account
+    create_account_tx = snx.core.create_account(submit=True)
+    snx.wait(create_account_tx)
+    new_account_id = snx.core.account_ids[-1]
+
+    # approve
+    allowance = snx.allowance(token.address, snx.core.core_proxy.address)
+    if allowance < USDC_LP_AMOUNT:
+        approve_core_tx = snx.approve(
+            token.address, snx.core.core_proxy.address, submit=True
+        )
+        snx.wait(approve_core_tx)
+
+    # deposit the token
+    deposit_tx_hash = snx.core.deposit(
+        token.address,
+        USDC_LP_AMOUNT,
+        decimals=usdc_decimals,
+        account_id=new_account_id,
+        submit=True,
+    )
+    deposit_tx_receipt = snx.wait(deposit_tx_hash)
+    assert deposit_tx_receipt.status == 1
+
+    # delegate the collateral
+    delegate_tx_hash = snx.core.delegate_collateral(
+        token.address,
+        USDC_LP_AMOUNT,
+        1,
+        account_id=new_account_id,
+        submit=True,
+    )
+    delegate_tx_receipt = snx.wait(delegate_tx_hash)
+    assert delegate_tx_receipt.status == 1
+
+    # mint sUSD
+    mint_tx_hash = snx.core.mint_usd(
+        token.address,
+        USDX_MINT_AMOUNT,
+        1,
+        account_id=new_account_id,
+        submit=True,
+    )
+    mint_tx_receipt = snx.wait(mint_tx_hash)
+    assert mint_tx_receipt.status == 1
+
+    # withdraw
+    withdraw_tx_hash = snx.core.withdraw(
+        USDX_MINT_AMOUNT,
+        token_address=susd.address,
+        decimals=susd_decimals,
+        account_id=new_account_id,
+        submit=True,
+    )
+    withdraw_tx_receipt = snx.wait(withdraw_tx_hash)
+    assert withdraw_tx_receipt.status == 1
+
+    # check balance
+    usdx_balance = snx.get_susd_balance()["balance"]
+    assert usdx_balance >= USDX_MINT_AMOUNT
+
+
+@chain_fork
+def liquidation_setup(snx, market_id):
+    snx.web3.provider.make_request("anvil_impersonateAccount", [SNX_DEPLOYER])
+
+    market = snx.perps.market_proxy
+    parameters = market.functions.getLiquidationParameters(market_id).call()
+    parameters[-1] = int(10**6 * 10**20)
+
+    tx_params = market.functions.setLiquidationParameters(
+        market_id, *parameters
+    ).build_transaction(
+        {
+            "from": SNX_DEPLOYER,
+            "nonce": snx.web3.eth.get_transaction_count(SNX_DEPLOYER),
+        }
+    )
+
+    # Send the transaction
+    tx_hash = snx.web3.eth.send_transaction(tx_params)
+    receipt = snx.wait(tx_hash)
+    if receipt["status"] != 1:
+        raise Exception("Set liquidation parameters failed")
+
+
+@chain_fork
 def wrap_eth(snx):
     """The instance can wrap ETH"""
     # check balance
     eth_balance = snx.get_eth_balance()
-    if eth_balance["weth"] < 10:
+    if eth_balance["weth"] < 100:
         snx.nonce = snx.web3.eth.get_transaction_count(snx.address)
-        tx_hash = snx.wrap_eth(10, submit=True)
+        tx_hash = snx.wrap_eth(100, submit=True)
         tx_receipt = snx.wait(tx_hash)
 
         assert tx_hash is not None
         assert tx_receipt is not None
         assert tx_receipt.status == 1
         snx.logger.info(f"Wrapped ETH")
+
+
+@chain_fork
+@pytest.fixture(scope="function")
+def perps_account_id(snx):
+    snx.logger.info("Creating a new perps account")
+    create_tx = snx.perps.create_account(submit=True)
+    snx.wait(create_tx)
+
+    account_ids = snx.perps.get_account_ids()
+    new_account_id = account_ids[-1]
+
+    yield new_account_id
 
 
 @chain_fork

--- a/tests/arbitrum-mainnet-fork/test_arb_mainnet_perps.py
+++ b/tests/arbitrum-mainnet-fork/test_arb_mainnet_perps.py
@@ -1,7 +1,7 @@
 import pytest
 import time
 import math
-from conftest import chain_fork, liquidation_setup
+from conftest import chain_fork, liquidation_setup, update_prices
 from ape import chain
 from utils.chain_helpers import mine_block
 
@@ -399,6 +399,12 @@ def test_alt_account_flow(
     margin_info = snx.perps.get_margin_info(perps_account_id)
     snx.logger.info(f"Margin info: {margin_info}")
 
+    # make really fresh prices
+    # this is required because otherwise this test can fail if the transaction simulation passes, but the transaction fails
+    # due to mismatched "block" timestamps and "real" timestamps
+    mine_block(snx, chain)
+    update_prices(snx)
+
     # withdraw for each collateral type
     for collateral_id, collateral_amount in margin_info["collateral_balances"].items():
         if collateral_amount > 0:
@@ -709,6 +715,12 @@ def test_alts_liquidation(snx, contracts, perps_account_id):
 
     # set the liquidation parameters
     liquidation_setup(snx, perps_market_id)
+
+    # make really fresh prices
+    # this is required because otherwise this test can fail if the transaction simulation passes, but the transaction fails
+    # due to mismatched "block" timestamps and "real" timestamps
+    mine_block(snx, chain)
+    update_prices(snx)
 
     # liquidate the account
     liquidate_tx = snx.perps.liquidate(perps_account_id, submit=True)

--- a/tests/arbitrum-mainnet-fork/test_arb_mainnet_perps.py
+++ b/tests/arbitrum-mainnet-fork/test_arb_mainnet_perps.py
@@ -1,0 +1,689 @@
+import pytest
+import time
+import math
+from conftest import chain_fork, liquidation_setup
+from ape import chain
+from utils.chain_helpers import mine_block
+
+# tests
+MARKET_NAMES = [
+    "ETH",
+    "BTC",
+    "SOL",
+    "WIF",
+]
+TEST_USD_COLLATERAL_AMOUNT = 1000
+TEST_ETH_COLLATERAL_AMOUNT = 0.5
+TEST_BTC_COLLATERAL_AMOUNT = 0.01
+TEST_POSITION_SIZE_USD = 50
+
+
+@chain_fork
+def test_perps_module(snx):
+    """The instance has a perps module"""
+    assert snx.perps is not None
+    assert snx.perps.market_proxy is not None
+    assert snx.perps.account_proxy is not None
+    assert snx.perps.account_ids is not None
+    assert snx.perps.markets_by_id is not None
+    assert snx.perps.markets_by_name is not None
+
+
+@chain_fork
+def test_perps_markets(snx):
+    markets_by_id, markets_by_name = snx.perps.get_markets()
+
+    snx.logger.info(f"Markets by id: {markets_by_id}")
+    snx.logger.info(f"Markets by name: {markets_by_name}")
+
+    assert markets_by_id is not None
+    assert markets_by_name is not None
+
+    for market in MARKET_NAMES:
+        assert (
+            market in markets_by_name
+        ), f"Market {market} is missing in markets_by_name"
+
+        market_summary = markets_by_name[market]
+        assert market_summary["market_name"] == market
+        assert market_summary["index_price"] > 0
+        assert market_summary["feed_id"] is not None
+
+
+@chain_fork
+def test_perps_account_fetch(snx, perps_account_id):
+    """The instance can fetch account ids"""
+    account_ids = snx.perps.get_account_ids()
+    snx.logger.info(
+        f"Address: {snx.address} - accounts: {len(account_ids)} - account_ids: {account_ids}"
+    )
+    assert len(account_ids) > 0
+    assert perps_account_id in account_ids
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "collateral_name, collateral_amount",
+    [
+        ("sUSD", TEST_USD_COLLATERAL_AMOUNT),
+        # ("sBTC", TEST_BTC_COLLATERAL_AMOUNT),
+        ("sETH", TEST_ETH_COLLATERAL_AMOUNT),
+    ],
+)
+def test_modify_collateral(
+    snx, contracts, perps_account_id, collateral_name, collateral_amount
+):
+    """Test modify collateral"""
+    # get collateral market id
+    collateral_id, collateral_name = snx.spot._resolve_market(
+        market_id=None, market_name=collateral_name
+    )
+
+    # get starting collateral and sUSD balance
+    margin_info_start = snx.perps.get_margin_info(perps_account_id)
+    susd_balance_start = snx.get_susd_balance()
+
+    # check allowance
+    allowance = snx.spot.get_allowance(
+        snx.perps.market_proxy.address, market_name=collateral_name
+    )
+    if allowance < collateral_amount:
+        approve_tx = snx.spot.approve(
+            snx.perps.market_proxy.address, market_name=collateral_name, submit=True
+        )
+        snx.wait(approve_tx)
+
+    # if not sUSD, wrap the asset first
+    if collateral_name != "sUSD":
+        # get the token
+        token_name = collateral_name[1:] if collateral_name != "sETH" else "WETH"
+        token = contracts[token_name]
+
+        # check the allowance
+        allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+        if allowance < collateral_amount:
+            # approve
+            approve_tx = snx.approve(
+                token.address, snx.spot.market_proxy.address, submit=True
+            )
+            snx.wait(approve_tx)
+
+        wrap_tx = snx.spot.wrap(
+            collateral_amount, market_name=collateral_name, submit=True
+        )
+        wrap_receipt = snx.wait(wrap_tx)
+        assert wrap_receipt.status == 1
+
+    # modify collateral
+    modify_tx = snx.perps.modify_collateral(
+        collateral_amount,
+        market_name=collateral_name,
+        account_id=perps_account_id,
+        submit=True,
+    )
+    modify_receipt = snx.wait(modify_tx)
+    assert modify_receipt["status"] == 1
+
+    # check the result
+    margin_info_end = snx.perps.get_margin_info(perps_account_id)
+
+    assert (
+        margin_info_end["total_collateral_value"]
+        > margin_info_start["total_collateral_value"]
+    )
+    assert margin_info_end["collateral_balances"][collateral_id] == collateral_amount
+
+    # modify collateral
+    modify_tx_2 = snx.perps.modify_collateral(
+        -collateral_amount,
+        market_name=collateral_name,
+        account_id=perps_account_id,
+        submit=True,
+    )
+    modify_receipt_2 = snx.wait(modify_tx_2)
+    assert modify_receipt_2["status"] == 1
+
+    # check the result
+    margin_info_final = snx.perps.get_margin_info(perps_account_id)
+
+    assert margin_info_final["total_collateral_value"] == 0
+    assert margin_info_final["collateral_balances"] == {}
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "market_name, collateral_name, collateral_amount",
+    [
+        ("ETH", "sUSD", TEST_USD_COLLATERAL_AMOUNT),
+        ("BTC", "sUSD", TEST_USD_COLLATERAL_AMOUNT),
+        # ("SOL", "sUSD", TEST_USD_COLLATERAL_AMOUNT),
+        # ("WIF", "sUSD", TEST_USD_COLLATERAL_AMOUNT),
+    ],
+)
+def test_usd_account_flow(
+    snx, perps_account_id, market_name, collateral_name, collateral_amount
+):
+    # get block and print
+    block = snx.web3.eth.get_block("latest")
+    susd_balance = snx.get_susd_balance()
+
+    snx.logger.info(f"Block: {block.number} - sUSD balance: {susd_balance}")
+
+    # check allowance
+    allowance = snx.spot.get_allowance(
+        snx.perps.market_proxy.address, market_name=collateral_name
+    )
+    if allowance < collateral_amount:
+        approve_tx = snx.spot.approve(
+            snx.perps.market_proxy.address, market_name=collateral_name, submit=True
+        )
+        snx.wait(approve_tx)
+
+    # deposit collateral
+    modify_tx = snx.perps.modify_collateral(
+        collateral_amount,
+        market_name=collateral_name,
+        account_id=perps_account_id,
+        submit=True,
+    )
+    modify_receipt = snx.wait(modify_tx)
+    assert modify_receipt["status"] == 1
+    snx.logger.info(snx.perps.get_margin_info(perps_account_id))
+
+    # get an updated price
+    index_price = snx.perps.markets_by_name[market_name]["index_price"]
+
+    # commit order
+    mine_block(snx, chain)
+    position_size = TEST_POSITION_SIZE_USD / index_price
+    commit_tx = snx.perps.commit_order(
+        position_size,
+        market_name=market_name,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt = snx.wait(commit_tx)
+    assert commit_receipt["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt = snx.wait(settle_tx)
+
+    # check the result
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=perps_account_id
+    )
+    assert round(position["position_size"], 12) == round(position_size, 12)
+
+    # get the position size
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=perps_account_id
+    )
+    size = position["position_size"]
+
+    # commit order
+    mine_block(snx, chain)
+    commit_tx_2 = snx.perps.commit_order(
+        -size,
+        market_name=market_name,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt_2 = snx.wait(commit_tx_2)
+    assert commit_receipt_2["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx_2 = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt_2 = snx.wait(settle_tx_2)
+
+    # check the result
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=perps_account_id
+    )
+    assert position["position_size"] == 0
+
+    # check the margin and withdraw
+    margin_info = snx.perps.get_margin_info(perps_account_id)
+    withdrawable_margin = margin_info["withdrawable_margin"]
+    withdrawable_margin = math.floor(withdrawable_margin * 1e8) / 1e8
+
+    modify_tx_2 = snx.perps.modify_collateral(
+        withdrawable_margin,
+        market_name=collateral_name,
+        account_id=perps_account_id,
+        submit=True,
+    )
+    modify_receipt_2 = snx.wait(modify_tx_2)
+    assert modify_receipt_2["status"] == 1
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    "market_name, collateral_name, collateral_amount",
+    [
+        # ("ETH", "sBTC", TEST_BTC_COLLATERAL_AMOUNT),
+        ("ETH", "sETH", TEST_ETH_COLLATERAL_AMOUNT),
+    ],
+)
+def test_alt_account_flow(
+    snx, contracts, perps_account_id, market_name, collateral_name, collateral_amount
+):
+    # get the token
+    token_name = collateral_name[1:] if collateral_name != "sETH" else "WETH"
+    token = contracts[token_name]
+
+    # check the allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+    if allowance < collateral_amount:
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        approve_receipt = snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(collateral_amount, market_name=collateral_name, submit=True)
+    wrap_receipt = snx.wait(wrap_tx)
+    assert wrap_receipt.status == 1
+
+    # check allowances
+    allowance = snx.spot.get_allowance(
+        snx.perps.market_proxy.address, market_name=collateral_name
+    )
+    if allowance < collateral_amount:
+        approve_tx = snx.spot.approve(
+            snx.perps.market_proxy.address, market_name=collateral_name, submit=True
+        )
+        snx.wait(approve_tx)
+
+    # deposit collateral
+    modify_tx = snx.perps.modify_collateral(
+        collateral_amount,
+        market_name=collateral_name,
+        account_id=perps_account_id,
+        submit=True,
+    )
+    modify_receipt = snx.wait(modify_tx)
+    assert modify_receipt["status"] == 1
+
+    # check the price
+    index_price = snx.perps.markets_by_name[market_name]["index_price"]
+
+    # commit order
+    mine_block(snx, chain)
+    position_size = TEST_POSITION_SIZE_USD / index_price
+    commit_tx = snx.perps.commit_order(
+        position_size,
+        market_name=market_name,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt = snx.wait(commit_tx)
+    assert commit_receipt["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt = snx.wait(settle_tx)
+
+    # check the result
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=perps_account_id
+    )
+    assert round(position["position_size"], 12) == round(position_size, 12)
+
+    # get the position size
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=perps_account_id
+    )
+    size = position["position_size"]
+
+    # commit order
+    mine_block(snx, chain)
+    commit_tx_2 = snx.perps.commit_order(
+        -size,
+        market_name=market_name,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt_2 = snx.wait(commit_tx_2)
+    assert commit_receipt_2["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx_2 = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt_2 = snx.wait(settle_tx_2)
+
+    # check the result
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=perps_account_id
+    )
+    assert position["position_size"] == 0
+
+    # check debt and repay
+    debt = snx.perps.get_margin_info(perps_account_id)["debt"]
+    if debt > 0:
+        # check allowance
+        allowance_usd = snx.spot.get_allowance(
+            snx.perps.market_proxy.address, market_id=0
+        )
+        if allowance_usd < debt:
+            approve_usd_tx = snx.spot.approve(
+                snx.perps.market_proxy.address, market_id=0, submit=True
+            )
+            snx.wait(approve_usd_tx)
+
+        # pay debt
+        paydebt_tx = snx.perps.pay_debt(
+            account_id=perps_account_id,
+            submit=True,
+        )
+        paydebt_receipt = snx.wait(paydebt_tx)
+        assert paydebt_receipt["status"] == 1
+
+    # check the margin and withdraw
+    margin_info = snx.perps.get_margin_info(perps_account_id)
+    snx.logger.info(f"Margin info: {margin_info}")
+
+    # withdraw for each collateral type
+    for collateral_id, collateral_amount in margin_info["collateral_balances"].items():
+        if collateral_amount > 0:
+            withdrawal_amount = math.floor(collateral_amount * 1e8) / 1e8
+            modify_tx = snx.perps.modify_collateral(
+                -withdrawal_amount,
+                market_id=collateral_id,
+                account_id=perps_account_id,
+                submit=True,
+            )
+            modify_receipt = snx.wait(modify_tx)
+
+            if modify_receipt["status"] != 1:
+                chain_receipt = chain.get_receipt(modify_tx)
+                snx.logger.info(f"{chain_receipt.show_trace()}")
+            assert modify_receipt["status"] == 1
+
+
+@chain_fork
+@pytest.mark.parametrize(
+    ["market_1", "market_2"],
+    [
+        ("ETH", "BTC"),
+    ],
+)
+def test_multiple_positions(snx, perps_account_id, market_1, market_2):
+    mine_block(snx, chain)
+
+    # check allowance
+    allowance = snx.spot.get_allowance(
+        snx.perps.market_proxy.address, market_name="sUSD"
+    )
+    if allowance < TEST_USD_COLLATERAL_AMOUNT:
+        approve_tx = snx.spot.approve(
+            snx.perps.market_proxy.address, market_name="sUSD", submit=True
+        )
+        snx.wait(approve_tx)
+
+    # deposit collateral
+    modify_tx = snx.perps.modify_collateral(
+        TEST_USD_COLLATERAL_AMOUNT,
+        market_name="sUSD",
+        account_id=perps_account_id,
+        submit=True,
+    )
+    modify_receipt = snx.wait(modify_tx)
+    assert modify_receipt["status"] == 1
+
+    ## order 1
+    # check the price
+    index_price_1 = snx.perps.markets_by_name[market_1]["index_price"]
+
+    # commit order
+    position_size_1 = TEST_POSITION_SIZE_USD / index_price_1
+    commit_tx_1 = snx.perps.commit_order(
+        position_size_1,
+        market_name=market_1,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt_1 = snx.wait(commit_tx_1)
+    assert commit_receipt_1["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx_1 = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt_1 = snx.wait(settle_tx_1)
+
+    ## order 2
+    # check the price
+    index_price_2 = snx.perps.markets_by_name[market_2]["index_price"]
+
+    # commit order
+    position_size_2 = TEST_POSITION_SIZE_USD / index_price_2
+    commit_tx_2 = snx.perps.commit_order(
+        position_size_2,
+        market_name=market_2,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt_2 = snx.wait(commit_tx_2)
+    assert commit_receipt_2["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx_2 = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt_2 = snx.wait(settle_tx_2)
+
+    # get the position sizes
+    positions = snx.perps.get_open_positions(account_id=perps_account_id)
+    size_1 = positions[market_1]["position_size"]
+    size_2 = positions[market_2]["position_size"]
+    assert round(size_1, 12) == round(position_size_1, 12)
+    assert round(size_2, 12) == round(position_size_2, 12)
+
+    ## order 1
+    # commit order
+    commit_tx_3 = snx.perps.commit_order(
+        -size_1,
+        market_name=market_1,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt_3 = snx.wait(commit_tx_3)
+    assert commit_receipt_3["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx_3 = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt_3 = snx.wait(settle_tx_3)
+
+    ## order 2
+    # commit order
+    commit_tx_4 = snx.perps.commit_order(
+        -size_2,
+        market_name=market_2,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt_4 = snx.wait(commit_tx_4)
+    assert commit_receipt_4["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx_4 = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt_4 = snx.wait(settle_tx_4)
+
+    # check the result
+    positions = snx.perps.get_open_positions(account_id=perps_account_id)
+    assert market_1 not in positions
+    assert market_2 not in positions
+
+
+@chain_fork
+def test_usd_liquidation(snx, perps_account_id):
+    market_name = "ETH"
+    market_id, market_name = snx.perps._resolve_market(None, market_name)
+    mine_block(snx, chain)
+
+    # check allowance
+    allowance = snx.spot.get_allowance(
+        snx.perps.market_proxy.address, market_name="sUSD"
+    )
+    if allowance < TEST_USD_COLLATERAL_AMOUNT:
+        approve_tx = snx.spot.approve(
+            snx.perps.market_proxy.address, market_name="sUSD", submit=True
+        )
+        snx.wait(approve_tx)
+
+    # deposit collateral
+    modify_tx = snx.perps.modify_collateral(
+        TEST_USD_COLLATERAL_AMOUNT,
+        market_name="sUSD",
+        account_id=perps_account_id,
+        submit=True,
+    )
+    modify_receipt = snx.wait(modify_tx)
+    assert modify_receipt["status"] == 1
+
+    # check the price
+    index_price = snx.perps.markets_by_name[market_name]["index_price"]
+
+    position_size = (TEST_USD_COLLATERAL_AMOUNT * 2) / index_price
+    commit_tx = snx.perps.commit_order(
+        position_size,
+        market_name=market_name,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt = snx.wait(commit_tx)
+    assert commit_receipt["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt = snx.wait(settle_tx)
+    assert settle_receipt["status"] == 1
+
+    # check the result
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=perps_account_id
+    )
+    assert round(position["position_size"], 12) == round(position_size, 12)
+
+    # set the liquidation parameters
+    liquidation_setup(snx, market_id)
+
+    # liquidate the account
+    liquidate_tx = snx.perps.liquidate(perps_account_id, submit=True)
+    liquidate_receipt = snx.wait(liquidate_tx)
+    assert liquidate_receipt["status"] == 1
+
+
+@chain_fork
+def test_eth_liquidation(snx, contracts, perps_account_id):
+    # get the token
+    market_name = "ETH"
+    token_name = "WETH"
+    token = contracts[token_name]
+
+    market_id, market_name = snx.perps._resolve_market(None, market_name)
+
+    # check spot market allowance
+    allowance = snx.allowance(token.address, snx.spot.market_proxy.address)
+    if allowance < TEST_ETH_COLLATERAL_AMOUNT:
+        # approve
+        approve_tx = snx.approve(
+            token.address, snx.spot.market_proxy.address, submit=True
+        )
+        approve_receipt = snx.wait(approve_tx)
+
+    wrap_tx = snx.spot.wrap(TEST_ETH_COLLATERAL_AMOUNT, market_name="sETH", submit=True)
+    wrap_receipt = snx.wait(wrap_tx)
+    if wrap_receipt.status != 1:
+        chain_receipt = chain.get_receipt(wrap_tx)
+        snx.logger.info(f"{chain_receipt.show_trace()}")
+    assert wrap_receipt.status == 1
+
+    # check perps market allowance
+    allowance = snx.spot.get_allowance(
+        snx.perps.market_proxy.address, market_name="sETH"
+    )
+    if allowance < TEST_ETH_COLLATERAL_AMOUNT:
+        approve_tx = snx.spot.approve(
+            snx.perps.market_proxy.address, market_name="sETH", submit=True
+        )
+        snx.wait(approve_tx)
+
+    # deposit collateral
+    modify_tx = snx.perps.modify_collateral(
+        TEST_ETH_COLLATERAL_AMOUNT,
+        market_name="sETH",
+        account_id=perps_account_id,
+        submit=True,
+    )
+    modify_receipt = snx.wait(modify_tx)
+    assert modify_receipt["status"] == 1
+
+    # check the price
+    index_price = snx.perps.markets_by_name[market_name]["index_price"]
+
+    mine_block(snx, chain)
+    position_size = (TEST_ETH_COLLATERAL_AMOUNT * 2) / index_price
+    commit_tx = snx.perps.commit_order(
+        position_size,
+        market_name=market_name,
+        account_id=perps_account_id,
+        settlement_strategy_id=0,
+        submit=True,
+    )
+    commit_receipt = snx.wait(commit_tx)
+    assert commit_receipt["status"] == 1
+
+    # wait for the order settlement
+    mine_block(snx, chain)
+    settle_tx = snx.perps.settle_order(
+        account_id=perps_account_id, max_tx_tries=5, submit=True
+    )
+    settle_receipt = snx.wait(settle_tx)
+    assert settle_receipt["status"] == 1
+
+    # check the result
+    position = snx.perps.get_open_position(
+        market_name=market_name, account_id=perps_account_id
+    )
+    assert round(position["position_size"], 12) == round(position_size, 12)
+
+    # set the liquidation parameters
+    liquidation_setup(snx, market_id)
+
+    # liquidate the account
+    liquidate_tx = snx.perps.liquidate(perps_account_id, submit=True)
+    liquidate_receipt = snx.wait(liquidate_tx)
+    assert liquidate_receipt["status"] == 1

--- a/tests/arbitrum-mainnet-fork/test_arb_mainnet_spot.py
+++ b/tests/arbitrum-mainnet-fork/test_arb_mainnet_spot.py
@@ -6,7 +6,8 @@ from ape import chain
 from utils.chain_helpers import mine_block
 
 # constants
-TEST_AMOUNT = 100
+TEST_USD_AMOUNT = 100
+TEST_ETH_AMOUNT = 1
 
 
 @chain_fork
@@ -30,13 +31,15 @@ def test_spot_markets(snx):
 @pytest.mark.parametrize(
     "token_name, test_amount, decimals",
     [
-        ("USDC", TEST_AMOUNT, 6),
+        ("USDC", TEST_USD_AMOUNT, 6),
+        ("WETH", TEST_ETH_AMOUNT, 18),
     ],
 )
 def test_spot_wrapper(snx, contracts, token_name, test_amount, decimals):
     """The instance can wrap and unwrap an asset"""
     token = contracts[token_name]
-    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token_name = "ETH" if token_name == "WETH" else token_name
+    market_id = snx.spot.markets_by_name[f"s{wrapped_token_name}"]["market_id"]
     wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
 
     # make sure we have some USDC
@@ -106,13 +109,15 @@ def test_spot_wrapper(snx, contracts, token_name, test_amount, decimals):
 @pytest.mark.parametrize(
     "token_name, test_amount, decimals",
     [
-        ("USDC", TEST_AMOUNT, 6),
+        ("USDC", TEST_USD_AMOUNT, 6),
+        # ("WETH", TEST_ETH_AMOUNT, 18),
     ],
 )
 def test_spot_async_order(snx, contracts, token_name, test_amount, decimals):
     """The instance can wrap USDC for sUSDC and commit an async order to sell for sUSD"""
     token = contracts[token_name]
-    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token_name = "ETH" if token_name == "WETH" else token_name
+    market_id = snx.spot.markets_by_name[f"s{wrapped_token_name}"]["market_id"]
 
     wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
     susd_token = snx.spot.markets_by_id[0]["contract"]
@@ -289,13 +294,15 @@ def test_spot_async_order(snx, contracts, token_name, test_amount, decimals):
 @pytest.mark.parametrize(
     "token_name, test_amount, decimals",
     [
-        ("USDC", TEST_AMOUNT, 6),
+        ("USDC", TEST_USD_AMOUNT, 6),
+        # ("WETH", TEST_ETH_AMOUNT, 18),
     ],
 )
 def test_spot_atomic_order(snx, contracts, token_name, test_amount, decimals):
     """The instance can wrap USDC for sUSDC and commit an atomic order to sell for sUSD"""
     token = contracts[token_name]
-    market_id = snx.spot.markets_by_name[f"s{token_name}"]["market_id"]
+    wrapped_token_name = "ETH" if token_name == "WETH" else token_name
+    market_id = snx.spot.markets_by_name[f"s{wrapped_token_name}"]["market_id"]
     wrapped_token = snx.spot.markets_by_id[market_id]["contract"]
     susd_token = snx.spot.markets_by_id[0]["contract"]
 

--- a/tests/arbitrum-mainnet-fork/test_arb_mainnet_spot.py
+++ b/tests/arbitrum-mainnet-fork/test_arb_mainnet_spot.py
@@ -114,7 +114,6 @@ def test_spot_wrapper(snx, contracts, token_name, test_amount, decimals):
         ("USDC", TEST_USD_AMOUNT, 6),
     ],
 )
-
 def test_spot_async_order(snx, contracts, token_name, test_amount, decimals):
     """The instance can wrap USDC for sUSDC and commit an async order to sell for sUSD"""
     token = contracts[token_name]
@@ -180,7 +179,11 @@ def test_spot_async_order(snx, contracts, token_name, test_amount, decimals):
     # commit order
     mine_block(snx, chain)
     commit_tx = snx.spot.commit_order(
-        "sell", test_amount, slippage_tolerance=0.001, market_id=market_id, submit=True
+        "sell",
+        test_amount,
+        slippage_tolerance=0.001,
+        market_id=market_id,
+        submit=True,
     )
     commit_receipt = snx.wait(commit_tx)
 
@@ -271,7 +274,7 @@ def test_spot_async_order(snx, contracts, token_name, test_amount, decimals):
     buy_susd_balance = snx.spot.get_balance(market_id=0)
 
     assert buy_balance == sold_balance
-    assert buy_synth_balance >= sold_synth_balance + test_amount - 2
+    assert buy_synth_balance >= sold_synth_balance + test_amount - 3
     assert buy_susd_balance >= sold_susd_balance - test_amount
 
     ## unwrap


### PR DESCRIPTION
Add tests for arbitrum mainnet:
- Test perps using all collateral types
- Test perps liquidations using all collateral type
- Test all spot markets using atomic and async orders

All of the tests pass individually, but some fail when running all tests due to timestamp issues on the fork.